### PR TITLE
fix: add #include <vector>

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <vector>
 struct module{
     std::string name;
     short grade;


### PR DESCRIPTION
### Description
Fixed compile error by  addding #include <vector>

G++ version: g++ (GCC) 15.1.1 20250425

Compile error:
```
g++ -std=c++20 -Wall -o modulrechner main.cpp
main.cpp:11:29: error: ‘vector’ in namespace ‘std’ does not name a template type
   11 | double calcGrade(const std::vector<module> &modules) {
      |                             ^~~~~~
main.cpp:4:1: note: ‘std::vector’ is defined in header ‘<vector>’; this is probably fixable by adding ‘#include <vector>’
    3 | #include <sstream>
  +++ |+#include <vector>
    4 | struct module {
main.cpp:11:35: error: expected ‘,’ or ‘...’ before ‘<’ token
   11 | double calcGrade(const std::vector<module> &modules) {
      |                                   ^
main.cpp: In function ‘double calcGrade(int)’:
main.cpp:14:29: error: ‘modules’ was not declared in this scope; did you mean ‘module’?
   14 |   for (const auto &module : modules) {
      |                             ^~~~~~~
      |                             module
main.cpp: In function ‘int main(int, char**)’:
main.cpp:43:8: error: ‘vector’ is not a member of ‘std’
   43 |   std::vector<struct module> modules;
      |        ^~~~~~
main.cpp:43:8: note: ‘std::vector’ is defined in header ‘<vector>’; this is probably fixable by adding ‘#include <vector>’
main.cpp:43:15: error: expected primary-expression before ‘struct’
   43 |   std::vector<struct module> modules;
      |               ^~~~~~
main.cpp:49:5: error: ‘modules’ was not declared in this scope; did you mean ‘module’?
   49 |     modules.push_back(m);
      |     ^~~~~~~
      |     module
main.cpp:51:51: error: ‘modules’ was not declared in this scope; did you mean ‘module’?
   51 |   std::cout << "Notendurchschnitt: " << calcGrade(modules) << '\n';
      |                                                   ^~~~~~~
      |                                                   module
```